### PR TITLE
ci: retrigger codecov

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,9 +9,6 @@ on:
   schedule:
     - cron: '6 10 * * 0'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   analyze:
     name: Analyze
@@ -32,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '6 10 * * 0'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/coverage-base-upload.yml
+++ b/.github/workflows/coverage-base-upload.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v5.0.0
+        uses: actions/setup-java@v5
         with:
           java-version: '8'
           distribution: 'temurin'
@@ -46,7 +46,7 @@ jobs:
         run: ./gradlew jacocoTestReport --no-daemon --no-build-cache
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v5
         with:
           name: base-jacoco-xml
           path: |
@@ -67,12 +67,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@v5
         with:
           name: base-jacoco-xml
           path: coverage-artifacts

--- a/.github/workflows/coverage-base-upload.yml
+++ b/.github/workflows/coverage-base-upload.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-base-coverage:
     name: Build Base Coverage

--- a/.github/workflows/coverage-base-upload.yml
+++ b/.github/workflows/coverage-base-upload.yml
@@ -11,9 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build-base-coverage:
     name: Build Base Coverage
@@ -22,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.0.0
         with:
           java-version: '8'
           distribution: 'temurin'
@@ -49,7 +46,7 @@ jobs:
         run: ./gradlew jacocoTestReport --no-daemon --no-build-cache
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: base-jacoco-xml
           path: |
@@ -70,12 +67,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5.0.0
         with:
           name: base-jacoco-xml
           path: coverage-artifacts

--- a/.github/workflows/coverage-pr-gen-artifact.yml
+++ b/.github/workflows/coverage-pr-gen-artifact.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v5.0.0
+        uses: actions/setup-java@v5
         with:
           java-version: '8'
           distribution: 'temurin'
@@ -44,7 +44,7 @@ jobs:
         run: ./gradlew jacocoTestReport  --no-daemon --no-build-cache
 
       - name: Upload JaCoCo artifact
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v5
         with:
           name: jacoco-coverage
           path: |

--- a/.github/workflows/coverage-pr-gen-artifact.yml
+++ b/.github/workflows/coverage-pr-gen-artifact.yml
@@ -12,9 +12,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build-coverage:
     name: Build ubuntu24 (JDK 8 / x86_64)
@@ -23,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.0.0
         with:
           java-version: '8'
           distribution: 'temurin'
@@ -47,7 +44,7 @@ jobs:
         run: ./gradlew jacocoTestReport  --no-daemon --no-build-cache
 
       - name: Upload JaCoCo artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: jacoco-coverage
           path: |

--- a/.github/workflows/coverage-pr-gen-artifact.yml
+++ b/.github/workflows/coverage-pr-gen-artifact.yml
@@ -12,6 +12,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-coverage:
     name: Build ubuntu24 (JDK 8 / x86_64)

--- a/.github/workflows/coverage-pr-upload.yml
+++ b/.github/workflows/coverage-pr-upload.yml
@@ -12,9 +12,6 @@ permissions:
   actions: read
   pull-requests: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   upload-coverage:
     name: Upload Coverage
@@ -27,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4  # must download source code
+        uses: actions/checkout@v5.0.0  # must download source code
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -42,7 +39,7 @@ jobs:
 
       - name: Get PR details
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const headSha = context.payload.workflow_run.head_sha;

--- a/.github/workflows/coverage-pr-upload.yml
+++ b/.github/workflows/coverage-pr-upload.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5.0.0  # must download source code
+        uses: actions/checkout@v5  # must download source code
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/coverage-pr-upload.yml
+++ b/.github/workflows/coverage-pr-upload.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: jacoco-coverage
           path: coverage

--- a/.github/workflows/coverage-pr-upload.yml
+++ b/.github/workflows/coverage-pr-upload.yml
@@ -12,6 +12,9 @@ permissions:
   actions: read
   pull-requests: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   upload-coverage:
     name: Upload Coverage

--- a/.github/workflows/coverage-project-waiting.yml
+++ b/.github/workflows/coverage-project-waiting.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Wait for codecov/project status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/math-check.yml
+++ b/.github/workflows/math-check.yml
@@ -7,6 +7,9 @@ on:
     branches: [ 'develop', 'release_**' ]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   check-math:
     runs-on: ubuntu-latest

--- a/.github/workflows/math-check.yml
+++ b/.github/workflows/math-check.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Create comment
         if: github.event_name == 'pull_request' && steps.check-math.outputs.math_found == 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/math-check.yml
+++ b/.github/workflows/math-check.yml
@@ -7,15 +7,12 @@ on:
     branches: [ 'develop', 'release_**' ]
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   check-math:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5.0.0
 
       - name: Check for java.lang.Math usage
         id: check-math
@@ -58,14 +55,14 @@ jobs:
 
       - name: Upload findings
         if: steps.check-math.outputs.math_found == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: math-usage-report
           path: math_usage.txt
 
       - name: Create comment
         if: github.event_name == 'pull_request' && steps.check-math.outputs.math_found == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/math-check.yml
+++ b/.github/workflows/math-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v5
 
       - name: Check for java.lang.Math usage
         id: check-math
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload findings
         if: steps.check-math.outputs.math_found == 'true'
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v5
         with:
           name: math-usage-report
           path: math_usage.txt

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -28,10 +28,10 @@ jobs:
             arch: aarch64
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v5
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5.0.0
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -55,10 +55,10 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5.0.0
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v5
 
       - name: Install dependencies (Rocky 8 + JDK8)
         run: |
@@ -139,7 +139,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v5
 
       - name: Install dependencies (Debian + build tools)
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
 
   build-macos:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -9,9 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
 
   build-macos:
@@ -31,10 +28,10 @@ jobs:
             arch: aarch64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5.0.0
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.0.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -58,10 +55,10 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5.0.0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.0.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -97,7 +94,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
 
       - name: Install dependencies (Rocky 8 + JDK8)
         run: |
@@ -142,7 +139,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
 
       - name: Install dependencies (Debian + build tools)
         run: |

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -11,9 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   pr-lint:
     name: PR Lint
@@ -22,7 +19,7 @@ jobs:
 
     steps:
       - name: Validate PR title and description
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -104,10 +101,10 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5.0.0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.0.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -126,7 +123,7 @@ jobs:
 
       - name: Upload Checkstyle reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: checkstyle-reports
           path: |

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -101,10 +101,10 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5.0.0
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload Checkstyle reports
         if: failure()
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v5
         with:
           name: checkstyle-reports
           path: |

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   pr-lint:
     name: PR Lint

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -19,20 +19,20 @@ jobs:
 
     steps:
       - name: Set up JDK 8
-        uses: actions/setup-java@v5.0.0
+        uses: actions/setup-java@v5
         with:
           java-version: '8'
           distribution: 'temurin'
 
       - name: Clone system-test
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v5
         with:
           repository: tronprotocol/system-test
           ref: release_workflow
           path: system-test
 
       - name: Checkout java-tron
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v5
         with:
           path: java-tron
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload FullNode log
         if: always()
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v5
         with:
           name: fullnode-log
           path: java-tron/fullnode.log

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   system-test:
     name: System Test (JDK 8 / x86_64)

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -11,9 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   system-test:
     name: System Test (JDK 8 / x86_64)
@@ -22,20 +19,20 @@ jobs:
 
     steps:
       - name: Set up JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.0.0
         with:
           java-version: '8'
           distribution: 'temurin'
 
       - name: Clone system-test
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
         with:
           repository: tronprotocol/system-test
           ref: release_workflow
           path: system-test
 
       - name: Checkout java-tron
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
         with:
           path: java-tron
 
@@ -88,7 +85,7 @@ jobs:
 
       - name: Upload FullNode log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: fullnode-log
           path: java-tron/fullnode.log


### PR DESCRIPTION
**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates CI workflows to enforce Node 24 for JavaScript actions via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`, and standardize to `actions/checkout@v5`, `actions/setup-java@v5`, `actions/upload-artifact@v5`, `actions/download-artifact@v5`, and `actions/github-script@v8` across coverage, CodeQL, PR checks/builds, math-check, and system tests. Retriggers Codecov to refresh coverage and status checks; CI-only, no application code changes.

<sup>Written for commit 2afc518247e80940024d73b32edac236fb4575eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows refreshed across builds, tests, coverage, PR checks, and system tests to use newer action releases.
  * Updates are limited to action/version pins; workflow behavior, step order, and logic remain unchanged to preserve CI stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->