### PR TITLE
ci: test multi pr over the same base

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -12,7 +12,7 @@ on:
         default: 'all'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
     branches: [ 'master','develop', 'release_**' ]
     types: [ opened, synchronize, reopened ]
+  workflow_dispatch:
+    inputs:
+      job:
+        description: 'Job to run: all / macos / ubuntu / rockylinux / debian11'
+        required: false
+        default: 'all'
+      ref:
+        description: 'Branch or commit SHA to run against'
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -13,7 +23,7 @@ jobs:
 
   build-macos:
     name: Build macos26 (JDK ${{ matrix.java }} / ${{ matrix.arch }})
-    #if: github.event.action != 'edited' && !failure() && !cancelled()
+    if: ${{ github.event_name == 'pull_request' || inputs.job == 'all' || inputs.job == 'macos' }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
@@ -50,7 +60,7 @@ jobs:
 
   build-ubuntu:
     name: Build ubuntu24 (JDK 17 / aarch64)
-    #if: github.event.action != 'edited' && !failure() && !cancelled()
+    if: ${{ github.event_name == 'pull_request' || inputs.job == 'all' || inputs.job == 'ubuntu' }}
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
 
@@ -80,7 +90,7 @@ jobs:
 
   docker-build-rockylinux:
     name: Build rockylinux (JDK 8 / x86_64)
-    #if: github.event.action != 'edited' && !failure() && !cancelled()
+    if: ${{ github.event_name == 'pull_request' || inputs.job == 'all' || inputs.job == 'rockylinux' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -123,7 +133,7 @@ jobs:
 
   docker-build-debian11:
     name: Build debian11 (JDK 8 / x86_64)
-    #if: github.event.action != 'edited' && !failure() && !cancelled()
+    if: ${{ github.event_name == 'pull_request' || inputs.job == 'all' || inputs.job == 'debian11' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -10,10 +10,6 @@ on:
         description: 'Job to run: all / macos / ubuntu / rockylinux / debian11'
         required: false
         default: 'all'
-      ref:
-        description: 'Branch or commit SHA to run against'
-        required: false
-        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI cancellations for concurrent PRs by scoping concurrency to the PR number. Adds manual `workflow_dispatch` with a `job` selector (`all`, `macos`, `ubuntu`, `rockylinux`, `debian11`) and targeted job conditions; removes the unused `ref` input.

<sup>Written for commit cd212d6efa69c1e2bf145c3a2aae59b58a2b44c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build workflow now supports manual triggering with selectable build targets, letting maintainers run specific platform builds or all builds on demand.
  * Improved concurrency handling to reduce duplicate runs and ensure builds are grouped per PR or branch.
  * Individual platform build jobs now run conditionally so manual selections or PR events only run the intended jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->