### PR TITLE
ci: fix the bug of No open pull request found

### DIFF
--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -43,13 +43,10 @@ jobs:
         with:
           script: |
             const headSha = context.payload.workflow_run.head_sha;
-            const headOwner = context.payload.workflow_run.head_repository.owner.login;
-            const headBranch = context.payload.workflow_run.head_branch;
-            const { data: pulls } = await github.rest.pulls.list({
+            const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              state: 'open',
-              head: `${headOwner}:${headBranch}`
+              commit_sha: headSha,
             });
             if (pulls.length > 0) {
               const pr = pulls[0];
@@ -58,7 +55,7 @@ jobs:
               core.setOutput('pr_branch', headBranch);
               core.setOutput('base_sha', pr.base.sha);
             } else {
-              core.setFailed(`No open pull request found for ${headOwner}:${headBranch}`);
+              core.setFailed(`No pull request found for commit ${headSha}`);
             }
 
       - name: Upload to Codecov


### PR DESCRIPTION
**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the coverage upload workflow to find the pull request by commit SHA, preventing false “No open pull request found” failures and restoring reliable Codecov uploads.

- **Bug Fixes**
  - Use `github.rest.repos.listPullRequestsAssociatedWithCommit` with `commit_sha` instead of `github.rest.pulls.list` filtered by `head`.
  - Works for merged/closed PRs and forked branches, not just open PRs.
  - Updated failure message to “No pull request found for commit <sha>”.

<sup>Written for commit 639e64ce56c5b47ef168400a71610f7f10ada6d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved pull request detection in the CI/CD pipeline's coverage upload workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->