### PR TITLE
ci: upgrade upload-artifac from v5 to v6

### DIFF
--- a/.github/workflows/coverage-gen.yml
+++ b/.github/workflows/coverage-gen.yml
@@ -44,7 +44,7 @@ jobs:
         run: ./gradlew jacocoTestReport  --no-daemon --no-build-cache
 
       - name: Upload JaCoCo artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: jacoco-coverage
           path: |

--- a/.github/workflows/coverage-update-baseline.yml
+++ b/.github/workflows/coverage-update-baseline.yml
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: base-jacoco-xml
           path: coverage-artifacts

--- a/.github/workflows/coverage-update-baseline.yml
+++ b/.github/workflows/coverage-update-baseline.yml
@@ -46,7 +46,7 @@ jobs:
         run: ./gradlew jacocoTestReport --no-daemon --no-build-cache
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: base-jacoco-xml
           path: |

--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: jacoco-coverage
           path: coverage

--- a/.github/workflows/math-check.yml
+++ b/.github/workflows/math-check.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload findings
         if: steps.check-math.outputs.math_found == 'true'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: math-usage-report
           path: math_usage.txt

--- a/.github/workflows/pr-cancel.yml
+++ b/.github/workflows/pr-cancel.yml
@@ -1,0 +1,42 @@
+name: Cancel PR Workflows on Close
+
+on:
+  pull_request:
+    types: [ closed ]
+
+permissions:
+  actions: write
+
+jobs:
+  cancel:
+    name: Cancel In-Progress Workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel PR Build and System Test
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const workflows = ['pr-build.yml', 'system-test.yml'];
+            const headSha = context.payload.pull_request.head.sha;
+
+            for (const workflowId of workflows) {
+              for (const status of ['in_progress', 'queued']) {
+                const { data } = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: workflowId,
+                  status,
+                });
+
+                for (const run of data.workflow_runs) {
+                  if (run.head_sha === headSha) {
+                    await github.rest.actions.cancelWorkflowRun({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      run_id: run.id,
+                    });
+                    console.log(`Cancelled ${workflowId} run #${run.id} (${status})`);
+                  }
+                }
+              }
+            }

--- a/.github/workflows/pr-cancel.yml
+++ b/.github/workflows/pr-cancel.yml
@@ -18,18 +18,26 @@ jobs:
           script: |
             const workflows = ['pr-build.yml', 'system-test.yml'];
             const headSha = context.payload.pull_request.head.sha;
+            const prNumber = context.payload.pull_request.number;
 
             for (const workflowId of workflows) {
               for (const status of ['in_progress', 'queued']) {
-                const { data } = await github.rest.actions.listWorkflowRuns({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: workflowId,
-                  status,
-                });
+                const runs = await github.paginate(
+                  github.rest.actions.listWorkflowRuns,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: workflowId,
+                    status,
+                    event: 'pull_request',
+                    per_page: 100,
+                  },
+                  (response) => response.data.workflow_runs
+                );
 
-                for (const run of data.workflow_runs) {
-                  if (run.head_sha === headSha) {
+                for (const run of runs) {
+                  const isTargetPr = run.pull_requests?.some((pr) => pr.number === prNumber);
+                  if (run.head_sha === headSha && isTargetPr) {
                     await github.rest.actions.cancelWorkflowRun({
                       owner: context.repo.owner,
                       repo: context.repo.repo,

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload Checkstyle reports
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: checkstyle-reports
           path: |

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload FullNode log
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: fullnode-log
           path: java-tron/fullnode.log

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -8,7 +8,7 @@ on:
     types: [ opened, synchronize, reopened ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `actions/upload-artifact`/`actions/download-artifact` to v6 across CI and switch `system-test` concurrency to PR numbers for safer parallel runs. Add a PR-close workflow that cancels only the matching PR runs to keep CI clean.

- **New Features**
  - Added `pr-cancel.yml` to cancel `pr-build.yml` and `system-test.yml` on PR close via `actions/github-script@v8`; filters by PR number and head SHA and targets in-progress/queued runs.

- **Dependencies**
  - Upgraded to `actions/upload-artifact@v6` and `actions/download-artifact@v6` in coverage (gen, upload, update-baseline), math-check, pr-check, and system-test workflows.

<sup>Written for commit 7735ebf715ec3bfd9bea641c49b1232b569e4c6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded CI artifact upload/download actions across multiple workflows for more reliable artifact handling (coverage, checkstyle, math usage, logs).
  * Adjusted system-test concurrency to prefer pull request numbers when available, improving job isolation and reliability.
* **New Features**
  * Added a workflow to cancel in-progress or queued PR-related CI runs automatically when a pull request is closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->