### PR TITLE
ci: fix the bug of pr-cancel and Autobuild

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,9 +36,16 @@ jobs:
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        build-mode: manual
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+    - name: Set up JDK 8
+      uses: actions/setup-java@v5
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+
+    - name: Build
+      run: ./gradlew build -x test --no-daemon
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/coverage-update-baseline.yml
+++ b/.github/workflows/coverage-update-baseline.yml
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: base-jacoco-xml
           path: coverage-artifacts

--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: jacoco-coverage
           path: coverage
@@ -43,13 +43,16 @@ jobs:
         with:
           script: |
             const headSha = context.payload.workflow_run.head_sha;
-            const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            const headOwner = context.payload.workflow_run.head_repository.owner.login;
+            const headBranch = context.payload.workflow_run.head_branch;
+            const { data: pulls } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              commit_sha: headSha,
+              state: 'all',
+              head: `${headOwner}:${headBranch}`,
             });
-            if (pulls.length > 0) {
-              const pr = pulls[0];
+            const pr = pulls.find((p) => p.head.sha === headSha);
+            if (pr) {
               core.setOutput('pr_number', pr.number);
               core.setOutput('pr_sha', headSha);
               core.setOutput('pr_branch', headBranch);

--- a/.github/workflows/pr-cancel.yml
+++ b/.github/workflows/pr-cancel.yml
@@ -36,7 +36,7 @@ jobs:
                 );
 
                 for (const run of runs) {
-                  const isTargetPr = run.pull_requests?.some((pr) => pr.number === prNumber);
+                  const isTargetPr = !run.pull_requests?.length || run.pull_requests.some((pr) => pr.number === prNumber);
                   if (run.head_sha === headSha && isTargetPr) {
                     await github.rest.actions.cancelWorkflowRun({
                       owner: context.repo.owner,

--- a/.github/workflows/pr-cancel.yml
+++ b/.github/workflows/pr-cancel.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const workflows = ['pr-build.yml', 'system-test.yml'];
+            const workflows = ['pr-build.yml', 'system-test.yml', 'codeql.yml', 'coverage-waiting.yml'];
             const headSha = context.payload.pull_request.head.sha;
             const prNumber = context.payload.pull_request.number;
 


### PR DESCRIPTION
**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PR cancellation, stabilizes CodeQL with a manual Gradle build on JDK 8, and repairs coverage upload PR detection. Prevents stuck analyses and ensures coverage and CodeQL runs map to the correct PRs.

- **Bug Fixes**
  - CodeQL: set `build-mode: manual`, install JDK 8 via `actions/setup-java@v5`, and run `./gradlew build -x test --no-daemon` instead of `github/codeql-action/autobuild@v4`.
  - pr-cancel: add `codeql.yml` and `coverage-waiting.yml` to the cancel list; treat runs with no `pull_requests` as the target PR when `head_sha` matches.
  - coverage: switch to `actions/download-artifact@v7` and fix PR detection in `coverage-upload.yml` by listing pulls for `head_owner:head_branch` and selecting the one matching `head_sha`.

<sup>Written for commit b0d34f8389d308d7bc91ec87fbd479d011c88e97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD build step made explicit and set to manual, including a specific Java setup, to ensure a consistent build before analysis (tests skipped).
  * Workflow cancellation broadened to include additional workflows and refined matching logic to reduce redundant runs.
  * Coverage pipeline updated to use the newer artifact download action and improved PR lookup to more reliably associate commits with pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->