### PR TITLE
ci: test pr-cancel 0xbigapple

### DIFF
--- a/.github/workflows/pr-cancel.yml
+++ b/.github/workflows/pr-cancel.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   cancel:
     name: Cancel In-Progress Workflows
+    if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     steps:
       - name: Cancel PR Build and System Test


### PR DESCRIPTION
**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the PR cancel GitHub Actions workflow to run only for unmerged PRs. Adds an `if: github.event.pull_request.merged == false` guard to the "Cancel In-Progress Workflows" job to prevent unnecessary runs on merged PRs.

<sup>Written for commit 1d968f69f5ace0855de0b6c0f09d515cc83ddeb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request workflow handling to prevent unnecessary operations on merged pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->