### PR TITLE
ci: test pr-cancel for liuyifei

### DIFF
--- a/.github/workflows/pr-cancel.yml
+++ b/.github/workflows/pr-cancel.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   cancel:
     name: Cancel In-Progress Workflows
+    if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     steps:
       - name: Cancel PR Build and System Test

--- a/.github/workflows/pr-cancel.yml
+++ b/.github/workflows/pr-cancel.yml
@@ -1,7 +1,7 @@
 name: Cancel PR Workflows on Close
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ closed ]
 
 permissions:
@@ -23,20 +23,16 @@ jobs:
 
             for (const workflowId of workflows) {
               for (const status of ['in_progress', 'queued']) {
-                const runs = await github.paginate(
-                  github.rest.actions.listWorkflowRuns,
-                  {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    workflow_id: workflowId,
-                    status,
-                    event: 'pull_request',
-                    per_page: 100,
-                  },
-                  (response) => response.data.workflow_runs
-                );
+                const { data } = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: workflowId,
+                  status,
+                  event: 'pull_request',
+                  per_page: 100,
+                });
 
-                for (const run of runs) {
+                for (const run of data.workflow_runs) {
                   const isTargetPr = !run.pull_requests?.length || run.pull_requests.some((pr) => pr.number === prNumber);
                   if (run.head_sha === headSha && isTargetPr) {
                     await github.rest.actions.cancelWorkflowRun({


### PR DESCRIPTION
**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the cancel workflow only when a PR is closed without being merged by switching to the `pull_request_target` closed event and adding `if: github.event.pull_request.merged == false`. This stops cancellations after merge and makes the job more reliable.

- **Bug Fixes**
  - Use `pull_request_target` on `closed` to run in the target repo context.
  - Replace `github.paginate(...listWorkflowRuns...)` with `listWorkflowRuns` and iterate over `data.workflow_runs` to avoid run listing issues.

<sup>Written for commit 848ed1b6f1598521d6540ac6bcfc5f8f4f9b2baa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved PR workflow efficiency: cancellation now only targets CI runs for unmerged pull requests, reducing unnecessary job cancellations.
  * Improved matching of workflow runs to ensure only the intended pipeline executions are canceled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->