### PR TITLE
ci: add paths-ignore for 3 time-cost ci

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,18 +6,9 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ 'develop' ]
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
-      - '.gitignore'
-      - '**/.gitignore'
-      - '.editorconfig'
-      - '.gitattributes'
-      - 'docs/**'
-      - 'CHANGELOG'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/PULL_REQUEST_TEMPLATE/**'
-      - '.github/CODEOWNERS'
+    paths-ignore: [ '**/*.md', '.gitignore', '**/.gitignore', '.editorconfig',
+                    '.gitattributes', 'docs/**', 'CHANGELOG', '.github/ISSUE_TEMPLATE/**',
+                    '.github/PULL_REQUEST_TEMPLATE/**', '.github/CODEOWNERS' ]
   schedule:
     - cron: '6 10 * * 0'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,18 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ 'develop' ]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - '.gitignore'
+      - '**/.gitignore'
+      - '.editorconfig'
+      - '.gitattributes'
+      - 'docs/**'
+      - 'CHANGELOG'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - '.github/CODEOWNERS'
   schedule:
     - cron: '6 10 * * 0'
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,18 +4,9 @@ on:
   pull_request:
     branches: [ 'master','develop', 'release_**' ]
     types: [ opened, synchronize, reopened ]
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
-      - '.gitignore'
-      - '**/.gitignore'
-      - '.editorconfig'
-      - '.gitattributes'
-      - 'docs/**'
-      - 'CHANGELOG'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/PULL_REQUEST_TEMPLATE/**'
-      - '.github/CODEOWNERS'
+    paths-ignore: [ '**/*.md', '.gitignore', '**/.gitignore', '.editorconfig',
+                    '.gitattributes', 'docs/**', 'CHANGELOG', '.github/ISSUE_TEMPLATE/**',
+                    '.github/PULL_REQUEST_TEMPLATE/**', '.github/CODEOWNERS' ]
   workflow_dispatch:
     inputs:
       job:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,6 +4,18 @@ on:
   pull_request:
     branches: [ 'master','develop', 'release_**' ]
     types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - '.gitignore'
+      - '**/.gitignore'
+      - '.editorconfig'
+      - '.gitattributes'
+      - 'docs/**'
+      - 'CHANGELOG'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - '.github/CODEOWNERS'
   workflow_dispatch:
     inputs:
       job:

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -6,18 +6,9 @@ on:
   pull_request:
     branches: [ 'develop', 'release_**' ]
     types: [ opened, synchronize, reopened ]
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
-      - '.gitignore'
-      - '**/.gitignore'
-      - '.editorconfig'
-      - '.gitattributes'
-      - 'docs/**'
-      - 'CHANGELOG'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/PULL_REQUEST_TEMPLATE/**'
-      - '.github/CODEOWNERS'
+    paths-ignore: [ '**/*.md', '.gitignore', '**/.gitignore', '.editorconfig',
+                    '.gitattributes', 'docs/**', 'CHANGELOG', '.github/ISSUE_TEMPLATE/**',
+                    '.github/PULL_REQUEST_TEMPLATE/**', '.github/CODEOWNERS' ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -6,6 +6,18 @@ on:
   pull_request:
     branches: [ 'develop', 'release_**' ]
     types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - '.gitignore'
+      - '**/.gitignore'
+      - '.editorconfig'
+      - '.gitattributes'
+      - 'docs/**'
+      - 'CHANGELOG'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - '.github/CODEOWNERS'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add paths-ignore to `codeql.yml`, `pr-build.yml`, and `system-test.yml` so these time-costly jobs skip non-code changes. We now ignore docs and text updates (`**/*.md`, `docs/**`, `CHANGELOG`), repo meta files (`.gitignore`, `**/.gitignore`, `.editorconfig`, `.gitattributes`), and `.github` templates/codeowners, using array syntax for consistency.

<sup>Written for commit 4c63777512a5df7c6937a220689b4a47ce03d7af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to skip running pull-request checks when changes are limited to documentation, changelogs, editor/git config, or repository template files—reducing unnecessary builds while preserving existing branch constraints and workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->