### PR TITLE
feat(plugin): fill section bloom using exist db

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -148,6 +148,36 @@ NOTE: large db may GC overhead limit exceeded.
 - `--db`: db name.
 - `-h | --help`: provide the help info
 
+## DB Backfill-Bloom
+
+DB backfill bloom provides the ability to backfill SectionBloom data for historical blocks to enable `eth_getLogs` address/topics filtering. This is useful when `isJsonRpcFilterEnabled` was disabled during block processing and later enabled, causing historical blocks to lack SectionBloom data.
+
+### Available parameters:
+
+- `-d | --database-directory`: Specify the database directory path, it is used to open the database to get the transaction log and write the SectionBloom data back, default: output-directory/database.
+- `-s | --start-block`: Specify the start block number for backfill (required).
+- `-e | --end-block`: Specify the end block number for backfill (optional, default: latest block).
+- `-c | --max-concurrency`: Specify the maximum concurrency for processing, default: 8.
+- `-h | --help`: Provide the help info.
+
+### Examples:
+
+```shell script
+# full command
+  java -jar Toolkit.jar db backfill-bloom [-h] -s=<startBlock> [-e=<endBlock>] [-d=<databaseDirectory>] [-c=<maxConcurrency>]
+# examples
+   java -jar Toolkit.jar db backfill-bloom -s 1000000 -e 2000000 #1. backfill blocks 1000000 to 2000000
+   java -jar Toolkit.jar db backfill-bloom -s 1000000 -d /path/to/database #2. specify custom database directory
+   java -jar Toolkit.jar db backfill-bloom -s 1000000 -c 8 #3. use higher concurrency (8 threads)
+```
+
+### Backfill speed
+
+The time required to process different block ranges varies. It is recommended to increase `--max-concurrency` appropriately to speed up the backfill process.
+
+- 0-10000000: It's done almost instantly because there are no logs inside.
+- 10000000-70000000: Takes about 3-4 hours/10,000,000 blocks with `--max-concurrency` set to 32.
+
 ## Keystore
 
 Keystore provides commands for managing account keystore files (Web3 Secret Storage format).

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -70,6 +70,7 @@ dependencies {
         implementation 'io.github.tronprotocol:leveldb:1.18.2'
     }
     implementation project(":protocol")
+    implementation project(":chainbase")
 }
 
 check.dependsOn 'lint'

--- a/plugins/src/main/java/common/org/tron/plugins/Db.java
+++ b/plugins/src/main/java/common/org/tron/plugins/Db.java
@@ -12,6 +12,7 @@ import picocli.CommandLine;
         DbConvert.class,
         DbLite.class,
         DbCopy.class,
+        DbBackfillBloom.class,
         DbRoot.class
     },
     commandListHeading = "%nCommands:%n%nThe most commonly used db commands are:%n"

--- a/plugins/src/main/java/common/org/tron/plugins/DbBackfillBloom.java
+++ b/plugins/src/main/java/common/org/tron/plugins/DbBackfillBloom.java
@@ -1,0 +1,463 @@
+package org.tron.plugins;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.extern.slf4j.Slf4j;
+import me.tongfei.progressbar.ProgressBar;
+import org.apache.commons.collections4.CollectionUtils;
+import org.tron.common.bloom.Bloom;
+import org.tron.common.es.ExecutorServiceManager;
+import org.tron.common.utils.ByteArray;
+import org.tron.common.utils.ByteUtil;
+import org.tron.core.capsule.TransactionRetCapsule;
+import org.tron.core.exception.BadItemException;
+import org.tron.core.exception.EventBloomException;
+import org.tron.plugins.utils.db.DBInterface;
+import org.tron.plugins.utils.db.DbTool;
+import picocli.CommandLine;
+
+@Slf4j(topic = "backfill-bloom")
+@CommandLine.Command(name = "backfill-bloom",
+    description = "Backfill SectionBloom for historical blocks to enable eth_getLogs filtering.",
+    exitCodeListHeading = "Exit Codes:%n",
+    exitCodeList = {
+        "0:Successful",
+        "1:Internal error: exception occurred, please check toolkit.log"})
+public class DbBackfillBloom implements Callable<Integer> {
+
+  @CommandLine.Spec
+  CommandLine.Model.CommandSpec spec;
+
+  @CommandLine.Option(names = {"--database-directory", "-d"},
+      defaultValue = "output-directory/database",
+      description = "Database directory path. Default: ${DEFAULT-VALUE}", order = 1)
+  private String databaseDirectory;
+
+  @CommandLine.Option(names = {"--start-block", "-s"}, required = true,
+      description = "Start block number for backfill", order = 2)
+  private long startBlock;
+
+  @CommandLine.Option(names = {"--end-block", "-e"},
+      description = "End block number for backfill (default: latest block)", order = 3)
+  private Long endBlock;
+
+  private static final int BLOCKS_PER_SECTION = 2048;
+
+  @CommandLine.Option(names = {"--max-concurrency", "-c"}, defaultValue = "8",
+      description = "Maximum concurrency for processing. Default: ${DEFAULT-VALUE}",
+      order = 5)
+  private int maxConcurrency;
+
+  @CommandLine.Option(names = {"--help", "-h"}, help = true,
+      description = "Display help message", order = 7)
+  private boolean help;
+
+  // Statistics
+  // Number of blocks traversed (including failed ones)
+  private final AtomicLong processedBlocks = new AtomicLong(0);
+  // Number of successfully processed blocks
+  private final AtomicLong successfulBlocks = new AtomicLong(0);
+  // Number of blocks containing logs
+  private final AtomicLong blocksWithLogs = new AtomicLong(0);
+  // Number of failed blocks processed
+  private final AtomicLong errorCount = new AtomicLong(0);
+  // Total number of bloom writes
+  private final AtomicLong totalBloomWrites = new AtomicLong(0);
+
+  private static class SectionRange {
+
+    final long start;
+    final long end;
+    final long sectionId;
+
+    SectionRange(long start, long end, long sectionId) {
+      this.start = start;
+      this.end = end;
+      this.sectionId = sectionId;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("Section %d: [%d-%d]", sectionId, start, end);
+    }
+  }
+
+  @Override
+  public Integer call() {
+    if (help) {
+      spec.commandLine().usage(System.out);
+      return 0;
+    }
+
+    try {
+      // Validate parameters
+      if (!validateParameters()) {
+        return 1;
+      }
+
+      // Initialize database connections
+      if (!initializeDatabase()) {
+        return 1;
+      }
+
+      // Determine end block if not specified
+      if (endBlock == null) {
+        endBlock = getLatestBlockNumber();
+        if (endBlock == null || endBlock == 0) {
+          spec.commandLine().getErr().println("Failed to determine latest block number");
+          return 1;
+        }
+      }
+
+      // Validate block range
+      if (endBlock < startBlock) {
+        spec.commandLine().getErr().println("End block must be >= start block");
+        return 1;
+      }
+
+      long totalBlocks = endBlock - startBlock + 1;
+      spec.commandLine().getOut().printf(
+          "Starting SectionBloom backfill for blocks %d to %d (%d blocks)%n",
+          startBlock, endBlock, totalBlocks);
+
+      // Process blocks with progress bar
+      long startTime = System.currentTimeMillis();
+      int result = processBlocks();
+      long duration = (System.currentTimeMillis() - startTime) / 1000;
+
+      // Print summary
+      printSummary(duration);
+
+      return result;
+
+    } catch (Exception e) {
+      logger.error("Backfill failed", e);
+      spec.commandLine().getErr().println("Backfill failed: " + e.getMessage());
+      return 1;
+    } finally {
+      DbTool.close();
+    }
+  }
+
+  private boolean validateParameters() {
+    if (startBlock < 0) {
+      spec.commandLine().getErr().println("Start block must be >= 0");
+      return false;
+    }
+
+    if (maxConcurrency <= 0 || maxConcurrency > 128) {
+      spec.commandLine().getErr().println("Max concurrency must be between 1 and 128");
+      return false;
+    }
+
+    File dbDir = new File(databaseDirectory);
+    if (!dbDir.exists() || !dbDir.isDirectory()) {
+      spec.commandLine().getErr().println("Database directory does not exist: "
+          + databaseDirectory);
+      return false;
+    }
+
+    return true;
+  }
+
+  private boolean initializeDatabase() {
+    try {
+      // Open both DBs here, single-threaded, before any worker thread starts. DbTool.getDB
+      // caches handles in a ConcurrentMap but its check-then-open is not atomic, so two
+      // threads opening the same LevelDB dir concurrently would hit the exclusive-lock error.
+      // Pre-warming the cache means the worker threads in processSection() only ever read the
+      // cached handles. Do NOT remove this pre-warm.
+      DbTool.getDB(databaseDirectory, "transactionRetStore");
+      DbTool.getDB(databaseDirectory, "section-bloom");
+
+      spec.commandLine().getOut().println("Database connections initialized successfully");
+      return true;
+    } catch (Exception e) {
+      logger.error("Failed to initialize database connections: {}", e.getMessage());
+      spec.commandLine().getErr().println("Failed to initialize database connections: "
+          + e.getMessage());
+      return false;
+    }
+  }
+
+  private Long getLatestBlockNumber() {
+    try {
+      DBInterface propertiesDb = DbTool.getDB(databaseDirectory, "properties");
+      byte[] latestBlockKey = "latest_block_header_number".getBytes();
+      byte[] latestBlockBytes = propertiesDb.get(latestBlockKey);
+
+      if (latestBlockBytes != null) {
+        return ByteArray.toLong(latestBlockBytes);
+      }
+      return null;
+    } catch (Exception e) {
+      logger.error("Failed to get latest block number: {}", e.getMessage());
+      return null;
+    }
+  }
+
+  private int processBlocks() {
+    long totalBlocks = endBlock - startBlock + 1;
+    // Calculate the section range to be processed
+    List<SectionRange> sectionRanges = calculateSectionRanges(startBlock, endBlock);
+
+    maxConcurrency = Math.min(maxConcurrency, sectionRanges.size());
+    ExecutorService executor =
+        ExecutorServiceManager.newFixedThreadPool("backfill-bloom", maxConcurrency);
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+    try (ProgressBar pb = new ProgressBar("Scanning blocks for SectionBloom backfill",
+        totalBlocks)) {
+      spec.commandLine().getOut().printf("Processing %d sections with %d threads\n",
+          sectionRanges.size(), maxConcurrency);
+      // Submit all section tasks to the thread pool
+      for (SectionRange range : sectionRanges) {
+        final long finalSectionStart = range.start;
+        final long finalSectionEnd = range.end;
+
+        CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+          try {
+            processSection(finalSectionStart, finalSectionEnd, pb);
+          } catch (Exception e) {
+            spec.commandLine().getOut().printf("Error processing section %d to %d, %s\n",
+                finalSectionStart, finalSectionEnd, e);
+          }
+        }, executor);
+
+        futures.add(future);
+      }
+
+      // Wait for all tasks to complete
+      CompletableFuture<Void> allTasks = CompletableFuture.allOf(futures.toArray(
+          new CompletableFuture[0]));
+
+      try {
+        allTasks.get();
+        spec.commandLine().getOut().printf("All %d batch tasks completed\n", futures.size());
+      } catch (Exception e) {
+        spec.commandLine().getOut().printf("Error waiting for tasks to complete: %s\n",
+            e.getMessage());
+        return 1;
+      }
+
+    } catch (Exception e) {
+      spec.commandLine().getOut().printf("Error in progress tracking %s\n", e);
+      return 1;
+    } finally {
+      ExecutorServiceManager.shutdownAndAwaitTermination(executor, "backfill-bloom");
+    }
+
+    return errorCount.get() > 0 ? 1 : 0;
+  }
+
+  /**
+   * Calculate the section range to be processed to ensure each thread processes a complete section.
+   * For example, startBlock=1000 and endBlock=4000 will generate:
+   * - SectionRange 0: [1000-2047]
+   * - SectionRange 1: [2048-4000]
+   */
+  private List<SectionRange> calculateSectionRanges(long startBlock, long endBlock) {
+    List<SectionRange> ranges = new ArrayList<>();
+
+    long currentBlock = startBlock;
+    while (currentBlock <= endBlock) {
+      // Calculate the section to which the current block belongs
+      long sectionId = currentBlock / BLOCKS_PER_SECTION;
+
+      // Calculate the boundaries of this section
+      long sectionStart = sectionId * BLOCKS_PER_SECTION;
+      long sectionEnd = sectionStart + BLOCKS_PER_SECTION - 1;
+
+      // Adjust to the actual range that needs to be processed
+      long rangeStart = Math.max(currentBlock, sectionStart);
+      long rangeEnd = Math.min(endBlock, sectionEnd);
+
+      ranges.add(new SectionRange(rangeStart, rangeEnd, sectionId));
+      currentBlock = sectionEnd + 1;
+    }
+
+    return ranges;
+  }
+
+  private void processSection(long sectionStart, long sectionEnd, ProgressBar pb) {
+    long sectionId = sectionStart / BLOCKS_PER_SECTION;
+    try {
+      // Cache hit only: these handles were pre-warmed single-threaded in initializeDatabase()
+      // to avoid a concurrent-open race on the same LevelDB dir.
+      DBInterface transactionRetDb = DbTool.getDB(databaseDirectory, "transactionRetStore");
+      DBInterface sectionBloomDb = DbTool.getDB(databaseDirectory, "section-bloom");
+
+      for (long blockNum = sectionStart; blockNum <= sectionEnd; blockNum++) {
+        try {
+          processBlock(blockNum, transactionRetDb, sectionBloomDb);
+          successfulBlocks.incrementAndGet();
+        } catch (Exception e) {
+          spec.commandLine().getOut().printf("Error processing block %d, %s\n", blockNum, e);
+          errorCount.incrementAndGet();
+        } finally {
+          processedBlocks.incrementAndGet();
+          pb.step();
+        }
+      }
+    } catch (Exception e) {
+      spec.commandLine().getOut().printf("Error in section %d processing: %s\n", sectionId, e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void processBlock(long blockNum, DBInterface transactionRetDb, DBInterface sectionBloomDb)
+      throws BadItemException, EventBloomException {
+
+    // Get transaction info for this block
+    byte[] blockKey = ByteArray.fromLong(blockNum);
+    byte[] transactionRetData = transactionRetDb.get(blockKey);
+
+    if (transactionRetData == null) {
+      return;
+    }
+
+    try {
+      TransactionRetCapsule transactionRetCapsule = new TransactionRetCapsule(transactionRetData);
+
+      // Create bloom filter for this block using the same logic as SectionBloomStore
+      Bloom blockBloom = Bloom.createBloom(transactionRetCapsule);
+
+      if (blockBloom != null) {
+        // Extract bit positions from bloom filter
+        List<Integer> bitList = extractBitPositions(blockBloom);
+
+        if (!CollectionUtils.isEmpty(bitList)) {
+          // Write to section bloom store using the same logic as SectionBloomStore.write
+          writeSectionBloom(blockNum, bitList, sectionBloomDb);
+          blocksWithLogs.incrementAndGet();
+        }
+      }
+    } catch (Exception e) {
+      spec.commandLine().getOut().printf("Error processing block %d: %s\n", blockNum,
+          e.getMessage());
+      throw e;
+    }
+  }
+
+  private List<Integer> extractBitPositions(Bloom blockBloom) {
+    List<Integer> bitList = new ArrayList<>();
+    BitSet bs = BitSet.valueOf(blockBloom.getData());
+    for (int i = bs.nextSetBit(0); i >= 0; i = bs.nextSetBit(i + 1)) {
+      // operate on index i here
+      if (i == Integer.MAX_VALUE) {
+        break; // or (i+1) would overflow
+      }
+      bitList.add(i);
+    }
+    return bitList;
+  }
+
+  private void writeSectionBloom(long blockNum, List<Integer> bitList, DBInterface sectionBloomDb)
+      throws EventBloomException {
+
+    int section = (int) (blockNum / BLOCKS_PER_SECTION);
+    int blockNumOffset = (int) (blockNum % BLOCKS_PER_SECTION);
+
+    for (int bitIndex : bitList) {
+      // Get existing BitSet from database
+      BitSet bitSet = getSectionBloomBitSet(section, bitIndex, sectionBloomDb);
+      if (Objects.isNull(bitSet)) {
+        bitSet = new BitSet(BLOCKS_PER_SECTION);
+      }
+
+      // Update the bit for this block
+      bitSet.set(blockNumOffset);
+
+      // Put back into database
+      putSectionBloomBitSet(section, bitIndex, bitSet, sectionBloomDb);
+      totalBloomWrites.incrementAndGet();
+    }
+  }
+
+  private long combineKey(int section, int bitIndex) {
+    return section * 1_000_000L + bitIndex;
+  }
+
+  private BitSet getSectionBloomBitSet(int section, int bitIndex, DBInterface sectionBloomDb)
+      throws EventBloomException {
+    long keyLong = combineKey(section, bitIndex);
+    byte[] key = Long.toHexString(keyLong).getBytes();
+    byte[] data = sectionBloomDb.get(key);
+
+    if (data == null) {
+      return null;
+    }
+
+    try {
+      byte[] decompressedData = ByteUtil.decompress(data);
+      return BitSet.valueOf(decompressedData);
+    } catch (Exception e) {
+      throw new EventBloomException("decompress byte failed");
+    }
+  }
+
+  private void putSectionBloomBitSet(int section, int bitIndex, BitSet bitSet,
+      DBInterface sectionBloomDb)
+      throws EventBloomException {
+    long keyLong = combineKey(section, bitIndex);
+    byte[] key = Long.toHexString(keyLong).getBytes();
+
+    try {
+      byte[] compressedData = ByteUtil.compress(bitSet.toByteArray());
+      sectionBloomDb.put(key, compressedData);
+    } catch (Exception e) {
+      throw new EventBloomException("compress byte failed");
+    }
+  }
+
+  private void printSummary(long duration) {
+    spec.commandLine().getOut().println("\n=== Backfill Summary ===");
+
+    spec.commandLine().getOut().printf("Total blocks scanned: %d%n", processedBlocks.get());
+    spec.commandLine().getOut().printf("Successfully processed: %d%n", successfulBlocks.get());
+    spec.commandLine().getOut().printf("Blocks with logs: %d%n", blocksWithLogs.get());
+    spec.commandLine().getOut().printf("Errors encountered: %d%n", errorCount.get());
+    spec.commandLine().getOut().printf("Duration: %d seconds%n", duration);
+
+    // Success rate statistics
+    if (processedBlocks.get() > 0) {
+      double successRate = (double) successfulBlocks.get() / processedBlocks.get() * 100;
+      double logRate = (double) blocksWithLogs.get() / processedBlocks.get() * 100;
+      spec.commandLine().getOut().printf("Success rate: %.2f%% (%d/%d)%n",
+          successRate, successfulBlocks.get(), processedBlocks.get());
+      spec.commandLine().getOut().printf("Blocks with logs rate: %.2f%% (%d/%d)%n",
+          logRate, blocksWithLogs.get(), processedBlocks.get());
+    }
+
+    // Performance statistics
+    spec.commandLine().getOut().printf("Total bloom writes: %d%n", totalBloomWrites.get());
+    spec.commandLine().getOut().printf("Max concurrency used: %d threads%n", maxConcurrency);
+    spec.commandLine().getOut().printf("Section-based processing: No locks needed%n");
+
+    if (duration > 0) {
+      spec.commandLine().getOut().printf("Scanning rate: %.2f blocks/second%n",
+          (double) processedBlocks.get() / duration);
+      spec.commandLine().getOut().printf("Processing rate: %.2f blocks/second%n",
+          (double) successfulBlocks.get() / duration);
+      if (totalBloomWrites.get() > 0) {
+        spec.commandLine().getOut().printf("Bloom write rate: %.2f writes/second%n",
+            (double) totalBloomWrites.get() / duration);
+      }
+    }
+
+    // Result judgment
+    if (errorCount.get() == 0) {
+      spec.commandLine().getOut().println("✓ Backfill completed successfully!");
+    } else {
+      spec.commandLine().getOut().printf("⚠ Backfill completed with %d errors.%n",
+          errorCount.get());
+    }
+  }
+}

--- a/plugins/src/test/java/org/tron/plugins/DbBackfillBloomTest.java
+++ b/plugins/src/test/java/org/tron/plugins/DbBackfillBloomTest.java
@@ -1,0 +1,374 @@
+package org.tron.plugins;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedStatic;
+import org.tron.common.utils.ByteArray;
+import org.tron.plugins.utils.db.DBInterface;
+import org.tron.plugins.utils.db.DbTool;
+import picocli.CommandLine;
+
+public class DbBackfillBloomTest {
+
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private String databaseDirectory;
+  private CommandLine cli;
+  private ByteArrayOutputStream outputStream;
+  private ByteArrayOutputStream errorStream;
+  private PrintStream originalOut;
+  private PrintStream originalErr;
+  private MockedStatic<DbTool> dbToolMock;
+
+  @Before
+  public void setUp() throws IOException {
+    // Create temporary database directory
+    databaseDirectory = temporaryFolder.newFolder().toString();
+
+    // Create the command line interface using Toolkit as the root command
+    cli = new CommandLine(new Toolkit());
+
+    // Capture output streams
+    outputStream = new ByteArrayOutputStream();
+    errorStream = new ByteArrayOutputStream();
+    originalOut = System.out;
+    originalErr = System.err;
+    System.setOut(new PrintStream(outputStream));
+    System.setErr(new PrintStream(errorStream));
+
+    // Mock DbTool static methods
+    dbToolMock = mockStatic(DbTool.class);
+  }
+
+  @After
+  public void tearDown() {
+    // Restore original streams
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+
+    // Close static mock
+    if (dbToolMock != null) {
+      dbToolMock.close();
+    }
+  }
+
+  @Test
+  public void testHelp() {
+    String[] args = new String[] { "db", "backfill-bloom", "-h" };
+    assertEquals(0, cli.execute(args));
+  }
+
+  @Test
+  public void testValidParametersWithMockedDatabase() throws Exception {
+    // Mock database interfaces
+    DBInterface transactionRetDb = mock(DBInterface.class);
+    DBInterface sectionBloomDb = mock(DBInterface.class);
+    DBInterface propertiesDb = mock(DBInterface.class);
+
+    // Mock DbTool.getDB calls
+    dbToolMock.when(() -> DbTool.getDB(anyString(), anyString()))
+        .thenAnswer(invocation -> {
+          String dbName = invocation.getArgument(1);
+          switch (dbName) {
+            case "transactionRetStore":
+              return transactionRetDb;
+            case "section-bloom":
+              return sectionBloomDb;
+            case "properties":
+              return propertiesDb;
+            default:
+              return mock(DBInterface.class);
+          }
+        });
+
+    // Mock latest block number
+    when(propertiesDb.get(any(byte[].class)))
+        .thenReturn(ByteArray.fromLong(1000L));
+
+    // Mock empty transaction data (no transactions to process)
+    when(transactionRetDb.get(any(byte[].class)))
+        .thenReturn(null);
+
+    String[] args = new String[] {
+        "db", "backfill-bloom",
+        "-d", databaseDirectory,
+        "-s", "100",
+        "-e", "200",
+        "-c", "2"
+    };
+
+    assertEquals(0, cli.execute(args));
+  }
+
+  @Test
+  public void testSummaryReportsScannedBlocks() throws Exception {
+    // Mock database interfaces
+    DBInterface transactionRetDb = mock(DBInterface.class);
+    DBInterface sectionBloomDb = mock(DBInterface.class);
+    DBInterface propertiesDb = mock(DBInterface.class);
+
+    dbToolMock.when(() -> DbTool.getDB(anyString(), anyString()))
+        .thenAnswer(invocation -> {
+          String dbName = invocation.getArgument(1);
+          switch (dbName) {
+            case "transactionRetStore":
+              return transactionRetDb;
+            case "section-bloom":
+              return sectionBloomDb;
+            case "properties":
+              return propertiesDb;
+            default:
+              return mock(DBInterface.class);
+          }
+        });
+
+    when(propertiesDb.get(any(byte[].class)))
+        .thenReturn(ByteArray.fromLong(1000L));
+    when(transactionRetDb.get(any(byte[].class)))
+        .thenReturn(null);
+
+    // Capture the command's output writer (summary is printed via
+    // spec.commandLine().getOut()). Follow the repo pattern: set the writer on a
+    // fresh root CommandLine, which picocli propagates to the subcommand on execute.
+    StringWriter out = new StringWriter();
+    CommandLine cmd = new CommandLine(new Toolkit());
+    cmd.setOut(new PrintWriter(out));
+
+    // Blocks 100..200 inclusive = 101 blocks scanned.
+    String[] args = new String[] {
+        "db", "backfill-bloom",
+        "-d", databaseDirectory,
+        "-s", "100",
+        "-e", "200",
+        "-c", "2"
+    };
+
+    assertEquals(0, cmd.execute(args));
+
+    // Guards against the regression where processedBlocks was never incremented,
+    // which made the whole summary report 0 scanned blocks and skip the rates.
+    String output = out.toString();
+    assertTrue(output.contains("Total blocks scanned: 101"));
+    assertTrue(output.contains("Success rate: 100.00%"));
+  }
+
+  @Test
+  public void testInvalidStartBlock() {
+    String[] args = new String[] {
+        "db", "backfill-bloom",
+        "-d", databaseDirectory,
+        "-s", "-1"
+    };
+    assertEquals(1, cli.execute(args));
+  }
+
+  @Test
+  public void testInvalidConcurrency() {
+    String[] args = new String[] {
+        "db", "backfill-bloom",
+        "-d", databaseDirectory,
+        "-s", "100",
+        "-c", "0"
+    };
+    assertEquals(1, cli.execute(args));
+  }
+
+  @Test
+  public void testInvalidConcurrencyTooHigh() {
+    String[] args = new String[] {
+        "db", "backfill-bloom",
+        "-d", databaseDirectory,
+        "-s", "100",
+        "-c", "200"
+    };
+    assertEquals(1, cli.execute(args));
+  }
+
+  @Test
+  public void testNonExistentDatabaseDirectory() {
+    String nonExistentDir = databaseDirectory + File.separator + UUID.randomUUID();
+    String[] args = new String[] {
+        "db", "backfill-bloom",
+        "-d", nonExistentDir,
+        "-s", "100"
+    };
+    assertEquals(1, cli.execute(args));
+  }
+
+  @Test
+  public void testEndBlockLessThanStartBlock() throws Exception {
+    // Mock database interfaces
+    DBInterface transactionRetDb = mock(DBInterface.class);
+    DBInterface sectionBloomDb = mock(DBInterface.class);
+
+    dbToolMock.when(() -> DbTool.getDB(anyString(), anyString()))
+        .thenAnswer(invocation -> {
+          String dbName = invocation.getArgument(1);
+          switch (dbName) {
+            case "transactionRetStore":
+              return transactionRetDb;
+            case "section-bloom":
+              return sectionBloomDb;
+            default:
+              return mock(DBInterface.class);
+          }
+        });
+
+    String[] args = new String[] {
+        "db", "backfill-bloom",
+        "-d", databaseDirectory,
+        "-s", "200",
+        "-e", "100"
+    };
+    assertEquals(1, cli.execute(args));
+  }
+
+  @Test
+  public void testDatabaseInitializationFailure() {
+    // Mock DbTool to throw exception
+    dbToolMock.when(() -> DbTool.getDB(anyString(), anyString()))
+        .thenThrow(new RuntimeException("Database connection failed"));
+
+    String[] args = new String[] {
+        "db", "backfill-bloom",
+        "-d", databaseDirectory,
+        "-s", "100"
+    };
+    assertEquals(1, cli.execute(args));
+  }
+
+  @Test
+  public void testAutoDetectEndBlock() throws Exception {
+    // Mock database interfaces
+    DBInterface transactionRetDb = mock(DBInterface.class);
+    DBInterface sectionBloomDb = mock(DBInterface.class);
+    DBInterface propertiesDb = mock(DBInterface.class);
+
+    dbToolMock.when(() -> DbTool.getDB(anyString(), anyString()))
+        .thenAnswer(invocation -> {
+          String dbName = invocation.getArgument(1);
+          switch (dbName) {
+            case "transactionRetStore":
+              return transactionRetDb;
+            case "section-bloom":
+              return sectionBloomDb;
+            case "properties":
+              return propertiesDb;
+            default:
+              return mock(DBInterface.class);
+          }
+        });
+
+    // Mock latest block number
+    when(propertiesDb.get(any(byte[].class)))
+        .thenReturn(ByteArray.fromLong(5000L));
+
+    // Mock empty transaction data
+    when(transactionRetDb.get(any(byte[].class)))
+        .thenReturn(null);
+
+    String[] args = new String[] {
+        "db", "backfill-bloom",
+        "-d", databaseDirectory,
+        "-s", "100"
+        // No end block specified - should auto-detect
+    };
+
+    assertEquals(0, cli.execute(args));
+  }
+
+  @Test
+  public void testFailedToGetLatestBlockNumber() throws Exception {
+    // Mock database interfaces
+    DBInterface transactionRetDb = mock(DBInterface.class);
+    DBInterface sectionBloomDb = mock(DBInterface.class);
+    DBInterface propertiesDb = mock(DBInterface.class);
+
+    dbToolMock.when(() -> DbTool.getDB(anyString(), anyString()))
+        .thenAnswer(invocation -> {
+          String dbName = invocation.getArgument(1);
+          switch (dbName) {
+            case "transactionRetStore":
+              return transactionRetDb;
+            case "section-bloom":
+              return sectionBloomDb;
+            case "properties":
+              return propertiesDb;
+            default:
+              return mock(DBInterface.class);
+          }
+        });
+
+    // Mock null latest block number (failed to get)
+    when(propertiesDb.get(any(byte[].class)))
+        .thenReturn(null);
+
+    String[] args = new String[] {
+        "db", "backfill-bloom",
+        "-d", databaseDirectory,
+        "-s", "100"
+        // No end block specified - should fail to auto-detect
+    };
+    assertEquals(1, cli.execute(args));
+  }
+
+  @Test
+  public void testDefaultParameters() throws Exception {
+    // Mock database interfaces
+    DBInterface transactionRetDb = mock(DBInterface.class);
+    DBInterface sectionBloomDb = mock(DBInterface.class);
+    DBInterface propertiesDb = mock(DBInterface.class);
+
+    dbToolMock.when(() -> DbTool.getDB(anyString(), anyString()))
+        .thenAnswer(invocation -> {
+          String dbName = invocation.getArgument(1);
+          switch (dbName) {
+            case "transactionRetStore":
+              return transactionRetDb;
+            case "section-bloom":
+              return sectionBloomDb;
+            case "properties":
+              return propertiesDb;
+            default:
+              return mock(DBInterface.class);
+          }
+        });
+
+    // Mock latest block number
+    when(propertiesDb.get(any(byte[].class)))
+        .thenReturn(ByteArray.fromLong(1000L));
+
+    // Mock empty transaction data
+    when(transactionRetDb.get(any(byte[].class)))
+        .thenReturn(null);
+
+    // Test with default database directory
+    String[] args = new String[] {
+        "db", "backfill-bloom",
+        "-s", "100",
+        "-e", "200"
+    };
+
+    // This should fail because default directory doesn't exist
+    assertEquals(1, cli.execute(args));
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

DB backfill-bloom provides the ability to backfill SectionBloom data for historical blocks to enable `eth_getLogs` address/topics filtering. This is useful when `isJsonRpcFilterEnabled` was disabled during block processing and later enabled, causing historical blocks to lack SectionBloom data.

**Why are these changes required?**

Refer to https://github.com/tronprotocol/java-tron/pull/6390

**This PR has been tested by:**

- Unit Tests
- Manual Testing

